### PR TITLE
WIP: feat: add notification icon and badge

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,8 @@ hexo.on('generateAfter', async function (post) {
         'date_published': newPost.date.format('L'),
         'summary': util.stripHTML(newPost.excerpt),
         'url': newPost.permalink,
+        'icon': util.full_url_for('/assets/images/favicon.ico'),
+        'badge': util.full_url_for('/assets/images/favicon.ico'),
         'tags': newPost.tags.data.map(function (v) { return v.name }),
         'categories': newPost.categories.data.map(function (v) { return v.name })
     }


### PR DESCRIPTION
We are missing notification icon and badge: https://developers.google.com/web/fundamentals/push-notifications/display-a-notification

Solution: add icon and badge for notification as site's favicon

See #5 

